### PR TITLE
Adds tests in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 recursive-include src/dependency_injector *.py *.pyx *.pxd *.c
+recursive-include tests *.py
 include README.rst
 include CONTRIBUTORS.rst
 include LICENSE.rst
 include requirements.txt
 include setup.py
+include tox.ini


### PR DESCRIPTION
I have added the `tests` directory and the `tox.ini` in `MANIFEST.in` to be able to run the tests after installing the source via PyPi to check if the installation ran successfully.

Motivation: https://github.com/NixOS/nixpkgs/pull/45871#issuecomment-417854526