### PR TITLE
Replace unsafe yaml.Loader in config.from_yaml

### DIFF
--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -1336,7 +1336,7 @@ cdef class ConfigurationOption(Provider):
 
         try:
             with open(filepath) as opened_file:
-                config = yaml.load(opened_file, yaml.Loader)
+                config = yaml.load(opened_file, yaml.SafeLoader)
         except IOError:
             return
 


### PR DESCRIPTION
As I mentioned in https://github.com/ets-labs/python-dependency-injector/issues/369#issuecomment-764913870, Loader is not safe and can be easily exploited.