### PR TITLE
Fix yaml configuration-envs-interpolation examples

### DIFF
--- a/docs/providers/configuration.rst
+++ b/docs/providers/configuration.rst
@@ -77,9 +77,9 @@ where ``examples/providers/configuration/config.yml`` is:
 .. code-block:: ini
 
    section:
-     option1: {$ENV_VAR}
-     option2: {$ENV_VAR}/path
-     option3: {$ENV_VAR:default}
+     option1: ${ENV_VAR}
+     option2: ${ENV_VAR}/path
+     option3: ${ENV_VAR:default}
 
 See also: :ref:`configuration-envs-interpolation`.
 


### PR DESCRIPTION
the interpolation of the environment variables example in yaml is wrong, I have changed the example from {$ ENV_VAR} to $ {ENV_VAR}