### PR TITLE
Fixed a typo in Factory provider docs "service.add_attributes(clent=client)" #499

### DIFF
--- a/examples/providers/factory_attribute_injections.py
+++ b/examples/providers/factory_attribute_injections.py
@@ -17,7 +17,7 @@ class Container(containers.DeclarativeContainer):
     client = providers.Factory(Client)
 
     service = providers.Factory(Service)
-    service.add_attributes(clent=client)
+    service.add_attributes(client=client)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed typo in docs
Closes #499 