### PR TITLE
569 fix numpy typing wiring

### DIFF
--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -321,11 +321,11 @@ class InspectFilter:
     def _is_starlette_request_cls(self, instance: object) -> bool:
         return starlette \
                and isinstance(instance, type) \
-               and self._is_subclass(instance, starlette.requests.Request)
+               and self._safe_is_subclass(instance, starlette.requests.Request)
 
-    def _is_subclass(self, instance: type, cls: type) -> bool:
+    def _safe_is_subclass(self, instance: type, cls: type) -> bool:
         try:
-            issubclass(instance, cls)
+            return issubclass(instance, cls)
         except TypeError:
             return False
 

--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -321,7 +321,13 @@ class InspectFilter:
     def _is_starlette_request_cls(self, instance: object) -> bool:
         return starlette \
                and isinstance(instance, type) \
-               and isinstance(instance, starlette.requests.Request)
+               and self._is_subclass(instance, starlette.requests.Request)
+
+    def _is_subclass(self, instance: type, cls: type) -> bool:
+        try:
+            issubclass(instance, cls)
+        except TypeError:
+            return False
 
     def _is_builtin(self, instance: object) -> bool:
         return inspect.isbuiltin(instance)

--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -321,7 +321,7 @@ class InspectFilter:
     def _is_starlette_request_cls(self, instance: object) -> bool:
         return starlette \
                and isinstance(instance, type) \
-               and issubclass(instance, starlette.requests.Request)
+               and isinstance(instance, starlette.requests.Request)
 
     def _is_builtin(self, instance: object) -> bool:
         return inspect.isbuiltin(instance)

--- a/tests/unit/samples/wiring/imports.py
+++ b/tests/unit/samples/wiring/imports.py
@@ -5,6 +5,7 @@ import sys
 if "pypy" not in sys.version.lower():
     import numpy  # noqa
     from numpy import *  # noqa
+    from numpy.typing import *  # noqa
 
     import scipy  # noqa
     from scipy import *  # noqa


### PR DESCRIPTION
Modify `InspectFilter._is_starlette_request_cls` by using a `_safe_is_subclass` method that returns `False` instead of raising a `TypeError`

closes #569 