### PR TITLE
Explicitly mention the required usage of "memo"

### DIFF
--- a/docs/providers/custom.rst
+++ b/docs/providers/custom.rst
@@ -16,8 +16,8 @@ To create a custom provider you need to follow these rules:
 1. New provider class should inherit :py:class:`Provider`.
 2. You need to implement the ``Provider._provide()`` method.
 3. You need to implement the ``Provider.__deepcopy__()`` method. It should return an
-   equivalent copy of a provider. All providers must be copied with a ``deepcopy()`` function
-   from the ``providers`` module. After the a new provider object is created use
+   equivalent copy of a provider. All providers must be copied with the ``deepcopy()`` function
+   from the ``providers`` module. It's essential to pass ``memo`` into ``deepcopy`` in order to keep the preconfigured ``args`` and ``kwargs`` of stored providers. After the a new provider object is created, use
    ``Provider._copy_overriding()`` method to copy all overriding providers. See the example
    below.
 4. If new provider has a ``__init__()`` method, it should call the parent
@@ -33,7 +33,7 @@ To create a custom provider you need to follow these rules:
 .. note::
    1. Prefer delegation over inheritance. If you choose between inheriting a ``Factory`` or
       inheriting a ``Provider`` and use ``Factory`` internally - the last is better.
-   2. When create a new provider follow the ``Factory``-like injections style. Consistency matters.
+   2. When creating a new provider follow the ``Factory``-like injections style. Consistency matters.
    3. Use the ``__slots__`` attribute to make sure nothing could be attached to your provider. You
       will also save some memory.
 


### PR DESCRIPTION
Wasted a couple of hours because I forgot to pass `memo` when using `deepcopy` 😄 
Mentioning it explicitly like this will hopefully prevent this for other people in the future.