### PR TITLE
Fix tests in examples/miniapps/fastapi

### DIFF
--- a/examples/miniapps/fastapi/giphynavigator/tests.py
+++ b/examples/miniapps/fastapi/giphynavigator/tests.py
@@ -3,13 +3,14 @@
 from unittest import mock
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 
 from giphynavigator.application import app
 from giphynavigator.giphy import GiphyClient
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client():
     async with AsyncClient(app=app, base_url="http://test") as client:
         yield client


### PR DESCRIPTION
I tried to download the examples/miniapps/fastapi.
After installing the dependencies, I ran the tests: 
```py.test giphynavigator/tests.py --cov=giphynavigator```

And got errors:
```
py.test giphynavigator/tests.py --cov=giphynavigator
============================================================================================================================= test session starts ==============================================================================================================================
platform linux -- Python 3.10.7, pytest-7.1.3, pluggy-1.0.0
rootdir: /home/mg/ws/lang_exp/python/python-dependency-injector
plugins: anyio-3.6.1, cov-3.0.0, asyncio-0.19.0
asyncio: mode=strict
collected 3 items                                                                                                                                                                                                                                                              

giphynavigator/tests.py FFF                                                                                                                                                                                                                                              [100%]

=================================================================================================================================== FAILURES ===================================================================================================================================
__________________________________________________________________________________________________________________________________ test_index __________________________________________________________________________________________________________________________________

client = <async_generator object client at 0x7fbe5e2c36c0>

    @pytest.mark.asyncio
    async def test_index(client):
        giphy_client_mock = mock.AsyncMock(spec=GiphyClient)
        giphy_client_mock.search.return_value = {
            "data": [
                {"url": "https://giphy.com/gif1.gif"},
                {"url": "https://giphy.com/gif2.gif"},
            ],
        }
    
        with app.container.giphy_client.override(giphy_client_mock):
>           response = await client.get(
                "/",
                params={
                    "query": "test",
                    "limit": 10,
                },
            )
E           AttributeError: 'async_generator' object has no attribute 'get'

giphynavigator/tests.py:31: AttributeError
....
=========================================================================================================================== short test summary info ============================================================================================================================
FAILED giphynavigator/tests.py::test_index - AttributeError: 'async_generator' object has no attribute 'get'
FAILED giphynavigator/tests.py::test_index_no_data - AttributeError: 'async_generator' object has no attribute 'get'
FAILED giphynavigator/tests.py::test_index_default_params - AttributeError: 'async_generator' object has no attribute 'get'
============================================================================================================================== 3 failed in 0.55s ===============================================================================================================================
```

So here's a fix for this problem.