### PR TITLE
fixed bug in windows build with default charset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ defined_macros = dict()
 defined_macros["CYTHON_CLINE_IN_TRACEBACK"] = 0
 
 # Getting description:
-with open("README.rst") as readme_file:
+with open("README.rst", encoding="utf-8") as readme_file:
     description = readme_file.read()
 
 # Getting requirements:


### PR DESCRIPTION
I got some problems when i tried to build the package on windows 11 with cp1251 encoding by default.
`UnicodeDecodeError: 'charmap' codec can't decode byte 0x98 in position 8667: character maps to <undefined>`