### PR TITLE
Fix `Closing` dependency resolution

### DIFF
--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -601,11 +601,11 @@ def _locate_dependent_closing_args(provider: providers.Provider) -> Dict[str, pr
     for arg in [*provider.args, *provider.kwargs.values()]:
         if not isinstance(arg, providers.Provider) or not hasattr(arg, "args"):
             continue
-
-        if not arg.args and isinstance(arg, providers.Resource):
+        if isinstance(arg, providers.Resource):
             return {str(id(arg)): arg}
-        else:
+        if arg.args or arg.kwargs:
             closing_deps |= _locate_dependent_closing_args(arg)
+
     return closing_deps
 
 

--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -605,7 +605,7 @@ def _locate_dependent_closing_args(provider: providers.Provider) -> Dict[str, pr
         if not arg.args and isinstance(arg, providers.Resource):
             return {str(id(arg)): arg}
         else:
-            closing_deps += _locate_dependent_closing_args(arg)
+            closing_deps |= _locate_dependent_closing_args(arg)
     return closing_deps
 
 

--- a/tests/unit/samples/wiringstringids/resourceclosing.py
+++ b/tests/unit/samples/wiringstringids/resourceclosing.py
@@ -25,6 +25,11 @@ class FactoryService:
         self.service = service
 
 
+class NestedService:
+    def __init__(self, factory_service: FactoryService):
+        self.factory_service = factory_service
+
+
 def init_service():
     service = Service()
     service.init()
@@ -36,6 +41,7 @@ class Container(containers.DeclarativeContainer):
 
     service = providers.Resource(init_service)
     factory_service = providers.Factory(FactoryService, service)
+    nested_service = providers.Factory(NestedService, factory_service)
 
 
 @inject
@@ -46,3 +52,10 @@ def test_function(service: Service = Closing[Provide["service"]]):
 @inject
 def test_function_dependency(factory: FactoryService = Closing[Provide["factory_service"]]):
     return factory
+
+
+@inject
+def test_function_nested_dependency(
+    nested: NestedService = Closing[Provide["nested_service"]]
+):
+    return nested

--- a/tests/unit/samples/wiringstringids/resourceclosing.py
+++ b/tests/unit/samples/wiringstringids/resourceclosing.py
@@ -92,6 +92,7 @@ def test_function_dependency_kwargs(factory: FactoryService = Closing[Provide["f
     return factory
 
 
+@inject
 def test_function_nested_dependency(
     nested: NestedService = Closing[Provide["nested_service"]]
 ):

--- a/tests/unit/samples/wiringstringids/resourceclosing.py
+++ b/tests/unit/samples/wiringstringids/resourceclosing.py
@@ -64,7 +64,7 @@ class Container(containers.DeclarativeContainer):
 
 class ContainerSingleton(containers.DeclarativeContainer):
 
-    singleton = providers.Resource(Singleton)
+    singleton = providers.Singleton(Singleton)
     service = providers.Resource(
         init_service_with_singleton,
         singleton
@@ -83,12 +83,16 @@ def test_function(service: Service = Closing[Provide["service"]]):
 
 
 @inject
-def test_function_dependency(factory: FactoryService = Closing[Provide["factory_service"]]):
+def test_function_dependency(
+    factory: FactoryService = Closing[Provide["factory_service"]]
+):
     return factory
 
 
 @inject
-def test_function_dependency_kwargs(factory: FactoryService = Closing[Provide["factory_service_kwargs"]]):
+def test_function_dependency_kwargs(
+    factory: FactoryService = Closing[Provide["factory_service_kwargs"]]
+):
     return factory
 
 

--- a/tests/unit/wiring/string_ids/test_main_py36.py
+++ b/tests/unit/wiring/string_ids/test_main_py36.py
@@ -33,7 +33,10 @@ def subcontainer():
     container.unwire()
 
 
-@fixture(params=[resourceclosing.Container, resourceclosing.ContainerSingleton])
+@fixture(params=[
+    resourceclosing.Container,
+    resourceclosing.ContainerSingleton,
+])
 def resourceclosing_container(request):
     container = request.param()
     container.wire(modules=[resourceclosing])

--- a/tests/unit/wiring/string_ids/test_main_py36.py
+++ b/tests/unit/wiring/string_ids/test_main_py36.py
@@ -307,6 +307,23 @@ def test_closing_dependency_resource():
 
 
 @mark.usefixtures("resourceclosing_container")
+def test_closing_nested_dependency_resource():
+    resourceclosing.Service.reset_counter()
+
+    result_1 = resourceclosing.test_function_nested_dependency()
+    assert isinstance(result_1, resourceclosing.NestedService)
+    assert result_1.factory_service.service.init_counter == 1
+    assert result_1.factory_service.service.shutdown_counter == 1
+
+    result_2 = resourceclosing.test_function_nested_dependency()
+    assert isinstance(result_2, resourceclosing.NestedService)
+    assert result_2.factory_service.service.init_counter == 2
+    assert result_2.factory_service.service.shutdown_counter == 2
+
+    assert result_1 is not result_2
+
+
+@mark.usefixtures("resourceclosing_container")
 def test_closing_resource_bypass_marker_injection():
     resourceclosing.Service.reset_counter()
 

--- a/tests/unit/wiring/string_ids/test_main_py36.py
+++ b/tests/unit/wiring/string_ids/test_main_py36.py
@@ -33,9 +33,9 @@ def subcontainer():
     container.unwire()
 
 
-@fixture
-def resourceclosing_container():
-    container = resourceclosing.Container()
+@fixture(params=[resourceclosing.Container, resourceclosing.ContainerSingleton])
+def resourceclosing_container(request):
+    container = request.param()
     container.wire(modules=[resourceclosing])
     yield container
     container.unwire()


### PR DESCRIPTION
Fix issues found when using `Closing` to implement per-function scope for `Resources`.

- Fixes #702: e.g. when a `Factory` depends on another `Factory` dependent on a `Resource`
- Fixes a problem with not closing a `Resource` when it is the last element in the dependency graph
- Incorporates #653 (thanks to @federinik)