### PR TITLE
Fix docker image version in asyncio daemon tutorial

### DIFF
--- a/docs/tutorials/asyncio-daemon.rst
+++ b/docs/tutorials/asyncio-daemon.rst
@@ -129,7 +129,7 @@ Put next lines into the ``requirements.txt`` file:
    pytest-cov
 
 Second, we need to create the ``Dockerfile``. It will describe the daemon's build process and
-specify how to run it. We will use ``python:3.9-buster`` as a base image.
+specify how to run it. We will use ``python:3.10-buster`` as a base image.
 
 Put next lines into the ``Dockerfile`` file:
 


### PR DESCRIPTION
In asyncio daemon tutorial, at the part before define the `Dockerfile` content, it's said it will use `python:3.9-buster`, but in `Dockerfile`, it uses `python:3.10-buster` in `FROM` tag.

This PR proposes set both as `python:3.10-buster` image version.