### PR TITLE
allow string imports outside of packages

### DIFF
--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -5034,7 +5034,7 @@ def _resolve_calling_module():
 
 def _resolve_calling_package_name():
     module = _resolve_calling_module()
-    return module.__package__
+    return getattr(module, "__package__", None)
 
 
 cpdef _copy_parent(object from_, object to, dict memo):


### PR DESCRIPTION
Problem description
=================

Currently, string imports are not possible outside of packages. 


Minimal reproducible example
=========================

The following code snippet executed from a script or Jupyter notebook cell raises an `AttributeError: 'NoneType' object has no attribute '__package__'`

```python
from dependency_injector import providers
deque_factory = providers.Factory('collections.deque')
```
The trace back reveals that the exception is thrown in `src/dependency_injector/providers.pyx in dependency_injector.providers._resolve_calling_package_name()`.

Proposal for solution
==================
In case the module in `dependency_injector.providers._resolve_calling_package_name` is `None`, the package should also be `None`. The subsequent call to `importlib.import_module` will handle the situation properly.
