### PR TITLE
Add additional version of Resources

### DIFF
--- a/src/dependency_injector/resources.py
+++ b/src/dependency_injector/resources.py
@@ -25,3 +25,13 @@ class AsyncResource(Generic[T], metaclass=abc.ABCMeta):
 
     async def shutdown(self, resource: Optional[T]) -> None:
         ...
+
+
+class AsyncShutdownResource(Generic[T], metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    def init(self, *args, **kwargs) -> Optional[T]:
+        ...
+
+    async def shutdown(self, resource: Optional[T]) -> None:
+        ...


### PR DESCRIPTION
It would be really useful to have a `Resource` type that is capable of having a sync `init` function with an async `shutdown`.

There are many scenarios where this is useful

Ex:

1. Create an [aiohttp client](https://docs.aiohttp.org/en/stable/client_quickstart.html#make-a-request).
`session = aiohttp.ClientSession()`

2. Before closing the app, I want to await any hanging connections
`await session.close()`
