### PR TITLE
update decoupled-example with abstraction layer

### DIFF
--- a/docs/examples/decoupled-packages.rst
+++ b/docs/examples/decoupled-packages.rst
@@ -55,6 +55,17 @@ file.
 
    ./
    ├── example/
+   │   ├── abstraction
+   │   │   ├── __init__.py
+   │   │   ├── analytics
+   │   │   │   ├── __init__.py
+   │   │   │   └── services.py
+   │   │   ├── photo
+   │   │   │   ├── __init__.py
+   │   │   │   └── repositories.py
+   │   │   └── user
+   │   │       ├── __init__.py
+   │   │       └── repositories.py
    │   ├── analytics/
    │   │   ├── __init__.py
    │   │   ├── containers.py
@@ -74,6 +85,26 @@ file.
    │   └── containers.py
    ├── config.ini
    └── requirements.txt
+
+
+Abstraction
+------------------
+
+Listing of the ``example/abstraction/user/repositories.py``:
+
+.. literalinclude:: ../../examples/miniapps/decoupled-packages/example/abstraction/user/repositories.py
+   :language: python
+
+Listing of the ``example/abstraction/photo/repositories.py``:
+
+.. literalinclude:: ../../examples/miniapps/decoupled-packages/example/abstraction/photo/repositories.py
+   :language: python
+
+Listing of the ``example/abstraction/analytics/services.py``:
+
+.. literalinclude:: ../../examples/miniapps/decoupled-packages/example/abstraction/analytics/services.py
+   :language: python
+
 
 Package containers
 ------------------

--- a/examples/miniapps/decoupled-packages/example/__main__.py
+++ b/examples/miniapps/decoupled-packages/example/__main__.py
@@ -2,21 +2,22 @@
 
 from dependency_injector.wiring import Provide, inject
 
-from .user.repositories import UserRepository
-from .photo.repositories import PhotoRepository
-from .analytics.services import AggregationService
+from .abstraction.user.repositories import UserRepositoryMeta
+from .abstraction.photo.repositories import PhotoRepositoryMeta
+from .abstraction.analytics.services import AggregationServiceMeta
+
 from .containers import ApplicationContainer
 
 
 @inject
 def main(
-        user_repository: UserRepository = Provide[
+        user_repository: UserRepositoryMeta = Provide[
             ApplicationContainer.user_package.user_repository
         ],
-        photo_repository: PhotoRepository = Provide[
+        photo_repository: PhotoRepositoryMeta = Provide[
             ApplicationContainer.photo_package.photo_repository
         ],
-        aggregation_service: AggregationService = Provide[
+        aggregation_service: AggregationServiceMeta = Provide[
             ApplicationContainer.analytics_package.aggregation_service
         ],
 ) -> None:
@@ -31,6 +32,8 @@ def main(
     assert aggregation_service.user_repository is user_repository
     assert aggregation_service.photo_repository is photo_repository
     print("Aggregate analytics from user and photo packages")
+
+    aggregation_service.call_user_photo()
 
 
 if __name__ == "__main__":

--- a/examples/miniapps/decoupled-packages/example/abstraction/__init__.py
+++ b/examples/miniapps/decoupled-packages/example/abstraction/__init__.py
@@ -1,0 +1,1 @@
+"""abstraction package."""

--- a/examples/miniapps/decoupled-packages/example/abstraction/analytics/__init__.py
+++ b/examples/miniapps/decoupled-packages/example/abstraction/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""abstraction analytics package."""

--- a/examples/miniapps/decoupled-packages/example/abstraction/analytics/services.py
+++ b/examples/miniapps/decoupled-packages/example/abstraction/analytics/services.py
@@ -1,0 +1,19 @@
+"""Analytics services module."""
+
+import abc
+
+
+from ..photo.repositories import PhotoRepositoryMeta
+from ..user.repositories import UserRepositoryMeta
+
+
+class AggregationServiceMeta(metaclass=abc.ABCMeta):
+
+    def __init__(self, user_repository: UserRepositoryMeta, photo_repository: PhotoRepositoryMeta):
+        self.user_repository: UserRepositoryMeta = user_repository
+        self.photo_repository: PhotoRepositoryMeta = photo_repository
+
+    @abc.abstractmethod
+    def call_user_photo(self):
+        """Must be implemented in order to instantiate."""
+        pass

--- a/examples/miniapps/decoupled-packages/example/abstraction/photo/__init__.py
+++ b/examples/miniapps/decoupled-packages/example/abstraction/photo/__init__.py
@@ -1,0 +1,1 @@
+"""abstraction photo package."""

--- a/examples/miniapps/decoupled-packages/example/abstraction/photo/repositories.py
+++ b/examples/miniapps/decoupled-packages/example/abstraction/photo/repositories.py
@@ -1,0 +1,11 @@
+"""Photo repositories Meta module."""
+
+import abc
+
+
+class PhotoRepositoryMeta(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    def get_photos(self, user_id):
+        """Must be implemented in order to instantiate."""
+        pass

--- a/examples/miniapps/decoupled-packages/example/abstraction/user/__init__.py
+++ b/examples/miniapps/decoupled-packages/example/abstraction/user/__init__.py
@@ -1,0 +1,1 @@
+"""abstraction user package."""

--- a/examples/miniapps/decoupled-packages/example/abstraction/user/repositories.py
+++ b/examples/miniapps/decoupled-packages/example/abstraction/user/repositories.py
@@ -1,0 +1,12 @@
+"""User repositories meta module."""
+
+
+import abc
+
+
+class UserRepositoryMeta(metaclass=abc.ABCMeta):
+
+    @abc.abstractmethod
+    def get(self, id):
+        """Must be implemented in order to instantiate."""
+        pass

--- a/examples/miniapps/decoupled-packages/example/analytics/containers.py
+++ b/examples/miniapps/decoupled-packages/example/analytics/containers.py
@@ -4,11 +4,14 @@ from dependency_injector import containers, providers
 
 from . import services
 
+from ..abstraction.photo.repositories import PhotoRepositoryMeta
+from ..abstraction.user.repositories import UserRepositoryMeta
+
 
 class AnalyticsContainer(containers.DeclarativeContainer):
 
-    user_repository = providers.Dependency()
-    photo_repository = providers.Dependency()
+    user_repository: UserRepositoryMeta = providers.Dependency()
+    photo_repository: PhotoRepositoryMeta = providers.Dependency()
 
     aggregation_service = providers.Singleton(
         services.AggregationService,

--- a/examples/miniapps/decoupled-packages/example/analytics/services.py
+++ b/examples/miniapps/decoupled-packages/example/analytics/services.py
@@ -1,8 +1,18 @@
 """Analytics services module."""
 
 
-class AggregationService:
+from ..abstraction.analytics.services import AggregationServiceMeta
+from ..abstraction.photo.repositories import PhotoRepositoryMeta
+from ..abstraction.user.repositories import UserRepositoryMeta
 
-    def __init__(self, user_repository, photo_repository):
-        self.user_repository = user_repository
-        self.photo_repository = photo_repository
+
+class AggregationService(AggregationServiceMeta):
+
+    def __init__(self, user_repository: UserRepositoryMeta, photo_repository: PhotoRepositoryMeta):
+        self.user_repository: UserRepositoryMeta = user_repository
+        self.photo_repository: PhotoRepositoryMeta = photo_repository
+
+    def call_user_photo(self):
+        user1 = self.user_repository.get(id=1)
+        user1_photos = self.photo_repository.get_photos(user1.id)
+        print(f"Retrieve user id={user1.id}, photos count={len(user1_photos)} from aggregation service.")

--- a/examples/miniapps/decoupled-packages/example/photo/repositories.py
+++ b/examples/miniapps/decoupled-packages/example/photo/repositories.py
@@ -1,7 +1,10 @@
 """Photo repositories module."""
 
 
-class PhotoRepository:
+from ..abstraction.photo.repositories import PhotoRepositoryMeta
+
+
+class PhotoRepository(PhotoRepositoryMeta):
 
     def __init__(self, entity_factory, fs, db):
         self.entity_factory = entity_factory

--- a/examples/miniapps/decoupled-packages/example/user/repositories.py
+++ b/examples/miniapps/decoupled-packages/example/user/repositories.py
@@ -1,7 +1,9 @@
 """User repositories module."""
 
+from ..abstraction.user.repositories import UserRepositoryMeta
 
-class UserRepository:
+
+class UserRepository(UserRepositoryMeta):
 
     def __init__(self, entity_factory, db):
         self.entity_factory = entity_factory


### PR DESCRIPTION
Hi 
The decoupled-example code is good, but it lack one important component of DIP rule **(https://www.cs.utexas.edu/users/downing/papers/DIP-1996.pdf)**
I mean the "Abstraction" layer which can help make "user" and "photo" compliant to abstract classes of their own and "analytics" depends on these abstract classes, and even for "analytics" can be extracted one abstract class, then for __main__.py (the top-level service aggregation) can only depend on these three abstract class, finally "ApplicationContainer" is for connecting the embodied containers("user", "photo", "analytics") to __main__.py.
The update code is better to demostrate DIP rule for developer.

I also update docs part.

Please check.
Thanks.