### PR TITLE
Modifying package for Pydantic Settings

### DIFF
--- a/docs/providers/configuration.rst
+++ b/docs/providers/configuration.rst
@@ -223,7 +223,7 @@ the container will call ``config.from_pydantic()`` automatically:
 
    or install ``pydantic`` directly::
 
-      pip install pydantic
+      pip install pydantic-settings
 
    *Don't forget to mirror the changes in the requirements file.*
 

--- a/examples/providers/configuration/configuration_pydantic.py
+++ b/examples/providers/configuration/configuration_pydantic.py
@@ -3,7 +3,7 @@
 import os
 
 from dependency_injector import containers, providers
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings, Field
 
 # Emulate environment variables
 os.environ["AWS_ACCESS_KEY_ID"] = "KEY"

--- a/examples/providers/configuration/configuration_pydantic_init.py
+++ b/examples/providers/configuration/configuration_pydantic_init.py
@@ -3,7 +3,7 @@
 import os
 
 from dependency_injector import containers, providers
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings, Field
 
 # Emulate environment variables
 os.environ["AWS_ACCESS_KEY_ID"] = "KEY"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ mypy
 pyyaml
 httpx
 fastapi
-pydantic
+pydantic-settings
 numpy
 scipy
 boto3

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(name="dependency-injector",
               "pyyaml",
           ],
           "pydantic": [
-              "pydantic",
+              "pydantic-settings",
           ],
           "flask": [
               "flask",

--- a/src/dependency_injector/providers.pyi
+++ b/src/dependency_injector/providers.pyi
@@ -27,7 +27,7 @@ except ImportError:
     yaml = None
 
 try:
-    import pydantic
+    import pydantic_settings as pydantic
 except ImportError:
     pydantic = None
 

--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -49,7 +49,7 @@ except ImportError:
     yaml = None
 
 try:
-    import pydantic
+    import pydantic_settings as pydantic
 except ImportError:
     pydantic = None
 

--- a/tests/typing/configuration.py
+++ b/tests/typing/configuration.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from dependency_injector import providers
-from pydantic import BaseSettings as PydanticSettings
+from pydantic_settings import BaseSettings as PydanticSettings
 
 
 # Test 1: to check the getattr

--- a/tests/unit/providers/configuration/test_from_pydantic_py36.py
+++ b/tests/unit/providers/configuration/test_from_pydantic_py36.py
@@ -1,6 +1,6 @@
 """Configuration.from_pydantic() tests."""
 
-import pydantic
+import pydantic_settings as pydantic
 from dependency_injector import providers, errors
 from pytest import fixture, mark, raises
 

--- a/tests/unit/providers/configuration/test_pydantic_settings_in_init_py36.py
+++ b/tests/unit/providers/configuration/test_pydantic_settings_in_init_py36.py
@@ -1,6 +1,6 @@
 """Configuration.from_pydantic() tests."""
 
-import pydantic
+import pydantic_settings as pydantic
 from dependency_injector import providers
 from pytest import fixture, mark, raises
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps=
     mypy_boto3_s3
 extras=
     yaml
-    pydantic
+    pydantic-settings
     flask
     aiohttp
 commands = pytest -c tests/.configs/pytest.ini


### PR DESCRIPTION
Pydantic has decoupled `BaseSettings` to a new package `pydantic-settings`, however the decencies are non updated 
for details please refer

https://docs.pydantic.dev/2.8/migration/#basesettings-has-moved-to-pydantic-settings 
