### PR TITLE
Add support for inspect.iscoroutinefunction() for Coroutine provider

### DIFF
--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import asyncio
 import copy
 import errno
 import functools
@@ -27,16 +28,18 @@ except ImportError:
     import __builtin__ as builtins
 
 try:
-    import asyncio
+    from inspect import _is_coroutine_mark as _is_coroutine_marker
 except ImportError:
-    asyncio = None
-    _is_coroutine_marker = None
-else:
-    if sys.version_info >= (3, 5, 3):
-        import asyncio.coroutines
-        _is_coroutine_marker = asyncio.coroutines._is_coroutine
-    else:
+    try:
+        # Python >=3.12.0,<3.12.5
+        from inspect import _is_coroutine_marker
+    except ImportError:
         _is_coroutine_marker = True
+
+try:
+    from asyncio.coroutines import _is_coroutine
+except ImportError:
+    _is_coroutine = True
 
 try:
     import ConfigParser as iniconfigparser
@@ -1475,7 +1478,8 @@ cdef class Coroutine(Callable):
         some_coroutine.add_kwargs(keyword_argument1=3, keyword_argument=4)
     """
 
-    _is_coroutine = _is_coroutine_marker
+    _is_coroutine_marker = _is_coroutine_marker  # Python >=3.12
+    _is_coroutine = _is_coroutine  # Python <3.16
 
     def set_provides(self, provides):
         """Set provider provides."""

--- a/tests/unit/providers/coroutines/test_coroutine_py35.py
+++ b/tests/unit/providers/coroutines/test_coroutine_py35.py
@@ -1,4 +1,5 @@
 """Coroutine provider tests."""
+import sys
 
 from dependency_injector import providers, errors
 from pytest import mark, raises
@@ -208,3 +209,17 @@ def test_repr():
         "<dependency_injector.providers."
         "Coroutine({0}) at {1}>".format(repr(example), hex(id(provider)))
     )
+
+
+@mark.skipif(sys.version_info > (3, 15), reason="requires Python<3.16")
+def test_asyncio_iscoroutinefunction() -> None:
+    from asyncio.coroutines import iscoroutinefunction
+
+    assert iscoroutinefunction(providers.Coroutine(example))
+
+
+@mark.skipif(sys.version_info < (3, 12), reason="requires Python>=3.12")
+def test_inspect_iscoroutinefunction() -> None:
+    from inspect import iscoroutinefunction
+
+    assert iscoroutinefunction(providers.Coroutine(example))


### PR DESCRIPTION
This improves Python 3.12+ support.

Background:
[@asyncio.coroutine](https://docs.python.org/3.10/library/asyncio-task.html#asyncio.coroutine) is no longer available since 3.11, [asyncio.iscoroutinefunction()](https://docs.python.org/3.10/library/asyncio-task.html#asyncio.iscoroutinefunction) was a helper function to detect generator-based coroutines, i.e. functions marked with `@asyncio.coroutine` decorator, which set `_is_coroutine` attribute. This implementation detail was historically abused to mark sync functions returning awaitables.
Since 3.12, [inspect.markcoroutinefunction()](https://docs.python.org/3.12/library/inspect.html#inspect.markcoroutinefunction) is a preferred way to mark sync functions returning awaitables. It is intended to be used with [inspect.iscoroutinefunction()](https://docs.python.org/3.12/library/inspect.html#inspect.iscoroutinefunction). Given the fact that we're in Cython realm, we have to resort to less graceful solution and [go deeper](https://github.com/python/cpython/blob/75872605aa78dbdfc5c4f025b0f90a7f37ba10c3/Lib/inspect.py#L307-L328) by abusing implementation details, again.

Note:
`asyncio.iscoroutinefunction()` [will be deprecated in 3.16](https://github.com/python/cpython/blob/75872605aa78dbdfc5c4f025b0f90a7f37ba10c3/Lib/asyncio/coroutines.py#L23-L26), so old marker is still in place for better compatibility.