### PR TITLE
Yet another Pydantic 2 support

### DIFF
--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -36,6 +36,17 @@ jobs:
         env:
           TOXENV: ${{ matrix.python-version }}
 
+  test-different-pydantic-versions:
+    name: Run tests with different pydantic versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - run: pip install tox
+      - run: tox -e pydantic-v1,pydantic-v2
+
   test-coverage:
     name: Run tests with coverage
     runs-on: ubuntu-latest

--- a/docs/providers/configuration.rst
+++ b/docs/providers/configuration.rst
@@ -183,22 +183,22 @@ See also: :ref:`configuration-envs-interpolation`.
 Loading from a Pydantic settings
 --------------------------------
 
-``Configuration`` provider can load configuration from a ``pydantic`` settings object using the
+``Configuration`` provider can load configuration from a ``pydantic_settings.BaseSettings`` object using the
 :py:meth:`Configuration.from_pydantic` method:
 
 .. literalinclude:: ../../examples/providers/configuration/configuration_pydantic.py
    :language: python
    :lines: 3-
-   :emphasize-lines: 31
+   :emphasize-lines: 32
 
-To get the data from pydantic settings ``Configuration`` provider calls ``Settings.dict()`` method.
+To get the data from pydantic settings ``Configuration`` provider calls its ``model_dump()`` method.
 If you need to pass an argument to this call, use ``.from_pydantic()`` keyword arguments.
 
 .. code-block:: python
 
    container.config.from_pydantic(Settings(), exclude={"optional"})
 
-Alternatively, you can provide a ``pydantic`` settings object over the configuration provider argument. In that case,
+Alternatively, you can provide a ``pydantic_settings.BaseSettings`` object over the configuration provider argument. In that case,
 the container will call ``config.from_pydantic()`` automatically:
 
 .. code-block:: python
@@ -215,17 +215,22 @@ the container will call ``config.from_pydantic()`` automatically:
 
 .. note::
 
-   ``Dependency Injector`` doesn't install ``pydantic`` by default.
+   ``Dependency Injector`` doesn't install ``pydantic-settings`` by default.
 
    You can install the ``Dependency Injector`` with an extra dependency::
 
-      pip install dependency-injector[pydantic]
+      pip install dependency-injector[pydantic2]
 
-   or install ``pydantic`` directly::
+   or install ``pydantic-settings`` directly::
 
-      pip install pydantic
+      pip install pydantic-settings
 
    *Don't forget to mirror the changes in the requirements file.*
+
+.. note::
+
+   For backward-compatibility, Pydantic v1 is still supported.
+   Passing ``pydantic.BaseSettings`` instances will work just as fine as ``pydantic_settings.BaseSettings``.
 
 Loading from a dictionary
 -------------------------

--- a/examples/miniapps/fastapi-redis/fastapiredis/tests.py
+++ b/examples/miniapps/fastapi-redis/fastapiredis/tests.py
@@ -3,7 +3,7 @@
 from unittest import mock
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from .application import app, container
 from .services import Service
@@ -11,7 +11,10 @@ from .services import Service
 
 @pytest.fixture
 def client(event_loop):
-    client = AsyncClient(app=app, base_url="http://test")
+    client = AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    )
     yield client
     event_loop.run_until_complete(client.aclose())
 

--- a/examples/miniapps/fastapi-simple/tests.py
+++ b/examples/miniapps/fastapi-simple/tests.py
@@ -1,14 +1,17 @@
 from unittest import mock
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from fastapi_di_example import app, container, Service
 
 
 @pytest.fixture
 async def client(event_loop):
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
         yield client
 
 

--- a/examples/miniapps/fastapi/giphynavigator/tests.py
+++ b/examples/miniapps/fastapi/giphynavigator/tests.py
@@ -3,7 +3,7 @@
 from unittest import mock
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from giphynavigator.application import app
 from giphynavigator.giphy import GiphyClient
@@ -11,7 +11,10 @@ from giphynavigator.giphy import GiphyClient
 
 @pytest.fixture
 async def client():
-    async with AsyncClient(app=app, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
         yield client
 
 

--- a/examples/providers/configuration/configuration_pydantic.py
+++ b/examples/providers/configuration/configuration_pydantic.py
@@ -3,7 +3,7 @@
 import os
 
 from dependency_injector import containers, providers
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Emulate environment variables
 os.environ["AWS_ACCESS_KEY_ID"] = "KEY"
@@ -11,15 +11,16 @@ os.environ["AWS_SECRET_ACCESS_KEY"] = "SECRET"
 
 
 class AwsSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="aws_")
 
-    access_key_id: str = Field(env="aws_access_key_id")
-    secret_access_key: str = Field(env="aws_secret_access_key")
+    access_key_id: str
+    secret_access_key: str
 
 
 class Settings(BaseSettings):
 
     aws: AwsSettings = AwsSettings()
-    optional: str = Field(default="default_value")
+    optional: str = "default_value"
 
 
 class Container(containers.DeclarativeContainer):

--- a/examples/providers/configuration/configuration_pydantic_init.py
+++ b/examples/providers/configuration/configuration_pydantic_init.py
@@ -3,7 +3,7 @@
 import os
 
 from dependency_injector import containers, providers
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Emulate environment variables
 os.environ["AWS_ACCESS_KEY_ID"] = "KEY"
@@ -11,15 +11,16 @@ os.environ["AWS_SECRET_ACCESS_KEY"] = "SECRET"
 
 
 class AwsSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="aws_")
 
-    access_key_id: str = Field(env="aws_access_key_id")
-    secret_access_key: str = Field(env="aws_secret_access_key")
+    access_key_id: str
+    secret_access_key: str
 
 
 class Settings(BaseSettings):
 
     aws: AwsSettings = AwsSettings()
-    optional: str = Field(default="default_value")
+    optional: str = "default_value"
 
 
 class Container(containers.DeclarativeContainer):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = ["six"]
 [project.optional-dependencies]
 yaml = ["pyyaml"]
 pydantic = ["pydantic"]
+pydantic2 = ["pydantic-settings"]
 flask = ["flask"]
 aiohttp = ["aiohttp"]
 

--- a/tests/.configs/pytest.ini
+++ b/tests/.configs/pytest.ini
@@ -2,6 +2,8 @@
 testpaths = tests/unit/
 python_files = test_*_py3*.py
 asyncio_mode = auto
+markers =
+    pydantic: Tests with Pydantic as a dependency
 filterwarnings =
     ignore:Module \"dependency_injector.ext.aiohttp\" is deprecated since version 4\.0\.0:DeprecationWarning
     ignore:Module \"dependency_injector.ext.flask\" is deprecated since version 4\.0\.0:DeprecationWarning

--- a/tests/unit/providers/configuration/test_pydantic_settings_in_init_py36.py
+++ b/tests/unit/providers/configuration/test_pydantic_settings_in_init_py36.py
@@ -1,35 +1,52 @@
 """Configuration.from_pydantic() tests."""
 
-import pydantic
-from dependency_injector import providers
+from pydantic import BaseModel
+
+try:
+    from pydantic_settings import (
+        BaseSettings,  # type: ignore[import-not-found,unused-ignore]
+    )
+except ImportError:
+    try:
+        from pydantic import BaseSettings  # type: ignore[no-redef,unused-ignore]
+    except ImportError:
+
+        class BaseSettings:  # type: ignore[no-redef]
+            """No-op fallback"""
+
+
 from pytest import fixture, mark, raises
 
+from dependency_injector import providers
 
-class Section11(pydantic.BaseModel):
+pytestmark = mark.pydantic
+
+
+class Section11(BaseModel):
     value1: int = 1
 
 
-class Section12(pydantic.BaseModel):
+class Section12(BaseModel):
     value2: int = 2
 
 
-class Settings1(pydantic.BaseSettings):
+class Settings1(BaseSettings):
     section1: Section11 = Section11()
     section2: Section12 = Section12()
 
 
-class Section21(pydantic.BaseModel):
+class Section21(BaseModel):
     value1: int = 11
     value11: int = 11
 
 
-class Section3(pydantic.BaseModel):
+class Section3(BaseModel):
     value3: int = 3
 
 
-class Settings2(pydantic.BaseSettings):
+class Settings2(BaseSettings):
     section1: Section21 = Section21()
-    section3: Section3= Section3()
+    section3: Section3 = Section3()
 
 
 @fixture
@@ -86,10 +103,10 @@ def test_copy(config, pydantic_settings_1, pydantic_settings_2):
 
 
 def test_set_pydantic_settings(config):
-    class Settings3(pydantic.BaseSettings):
+    class Settings3(BaseSettings):
         ...
 
-    class Settings4(pydantic.BaseSettings):
+    class Settings4(BaseSettings):
         ...
 
     settings_3 = Settings3()
@@ -100,27 +117,27 @@ def test_set_pydantic_settings(config):
 
 
 def test_file_does_not_exist(config):
-    config.set_pydantic_settings([pydantic.BaseSettings()])
+    config.set_pydantic_settings([BaseSettings()])
     config.load()
     assert config() == {}
 
 
 @mark.parametrize("config_type", ["strict"])
 def test_file_does_not_exist_strict_mode(config):
-    config.set_pydantic_settings([pydantic.BaseSettings()])
+    config.set_pydantic_settings([BaseSettings()])
     with raises(ValueError):
         config.load()
     assert config() == {}
 
 
 def test_required_file_does_not_exist(config):
-    config.set_pydantic_settings([pydantic.BaseSettings()])
+    config.set_pydantic_settings([BaseSettings()])
     with raises(ValueError):
         config.load(required=True)
 
 
 @mark.parametrize("config_type", ["strict"])
 def test_not_required_file_does_not_exist_strict_mode(config):
-    config.set_pydantic_settings([pydantic.BaseSettings()])
+    config.set_pydantic_settings([BaseSettings()])
     config.load(required=False)
     assert config() == {}

--- a/tests/unit/wiring/test_fastapi_py36.py
+++ b/tests/unit/wiring/test_fastapi_py36.py
@@ -1,4 +1,4 @@
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from pytest import fixture, mark
 from pytest_asyncio import fixture as aio_fixture
 
@@ -19,7 +19,7 @@ from wiringfastapi import web
 
 @aio_fixture
 async def async_client():
-    client = AsyncClient(app=web.app, base_url="http://test")
+    client = AsyncClient(transport=ASGITransport(app=web.app), base_url="http://test")
     yield client
     await client.aclose()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 parallel_show_output = true
 envlist=
-    coveralls, pylint, flake8, pydocstyle, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy3.9, pypy3.10
+    coveralls, pylint, flake8, pydocstyle, pydantic-v1, pydantic-v2, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy3.9, pypy3.10
 
 [testenv]
 deps=
@@ -28,6 +28,27 @@ setenv =
 
 [testenv:.pkg]
 passenv = DEPENDENCY_INJECTOR_*
+
+[testenv:pydantic-{v1,v2}]
+description = run tests with different pydantic versions
+base_python = python3.12
+deps =
+    v1: pydantic<2
+    v2: pydantic-settings
+    pytest
+    pytest-asyncio
+    -rrequirements.txt
+    typing_extensions
+    httpx
+    fastapi
+    flask<2.2
+    aiohttp<=3.9.0b1
+    numpy
+    scipy
+    boto3
+    mypy_boto3_s3
+    werkzeug<=2.2.2
+commands = pytest -c tests/.configs/pytest.ini -m pydantic
 
 [testenv:coveralls]
 passenv = GITHUB_*, COVERALLS_*, DEPENDENCY_INJECTOR_*


### PR DESCRIPTION
This PR supersede #803, #786, #785 (partially), #768 and fixes #755, #726.

Notable differences:
* Updated GHA pipeline to run tests against two versions of Pydantic.
* Better error messages depending on installed Pydantic version.
* Minor code de-duplication.

There is one necessary but unrelated commit to fix compatibility with httpx [v0.27.0](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0270-21st-february-2024). Without this change tests are failing.