### PR TITLE
Upgrade testing deps

### DIFF
--- a/requirements-ext.txt
+++ b/requirements-ext.txt
@@ -1,3 +1,3 @@
-flask==2.1.3
-werkzeug==2.2.2
+flask
+werkzeug
 aiohttp

--- a/tests/typing/configuration.py
+++ b/tests/typing/configuration.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any
 
 from dependency_injector import providers
-from pydantic import BaseSettings as PydanticSettings
+from pydantic_settings import BaseSettings as PydanticSettings
 
 
 # Test 1: to check the getattr

--- a/tests/unit/samples/wiringflask/web.py
+++ b/tests/unit/samples/wiringflask/web.py
@@ -1,11 +1,9 @@
 from flask import Flask, jsonify, request, current_app, session, g
-from flask import _request_ctx_stack, _app_ctx_stack
 from dependency_injector import containers, providers
 from dependency_injector.wiring import inject, Provide
 
 # This is here for testing wiring bypasses these objects without crashing
 request, current_app, session, g  # noqa
-_request_ctx_stack, _app_ctx_stack  # noqa
 
 
 class Service:

--- a/tox.ini
+++ b/tox.ini
@@ -7,18 +7,16 @@ envlist=
 deps=
     pytest
     pytest-asyncio
-    # TODO: Hotfix, remove when fixed https://github.com/aio-libs/aiohttp/issues/5107
-    typing_extensions
     httpx
     fastapi
-    flask<2.2
-    aiohttp<=3.9.0b1
+    flask
+    aiohttp
     numpy
     scipy
     boto3
     mypy_boto3_s3
-    pydantic<2
-    werkzeug<=2.2.2
+    pydantic-settings
+    werkzeug
 extras=
     yaml
 commands = pytest -c tests/.configs/pytest.ini
@@ -41,13 +39,13 @@ deps =
     typing_extensions
     httpx
     fastapi
-    flask<2.2
-    aiohttp<=3.9.0b1
+    flask
+    aiohttp
     numpy
     scipy
     boto3
     mypy_boto3_s3
-    werkzeug<=2.2.2
+    werkzeug
 commands = pytest -c tests/.configs/pytest.ini -m pydantic
 
 [testenv:coveralls]
@@ -69,9 +67,9 @@ deps=
     pytest
     pytest-asyncio
     httpx
-    flask<2.2
-    pydantic<2
-    werkzeug<=2.2.2
+    flask
+    pydantic-settings
+    werkzeug
     fastapi
     boto3
     mypy_boto3_s3
@@ -83,8 +81,8 @@ commands = pytest -c tests/.configs/pytest-py35.ini
 [testenv:pylint]
 deps=
     pylint
-    flask<2.2
-    werkzeug<=2.2.2
+    flask
+    werkzeug
 commands=
     - pylint -f colorized src/dependency_injector
 
@@ -105,7 +103,7 @@ commands=
 [testenv:mypy]
 deps=
     typing_extensions
-    pydantic<2
+    pydantic-settings
     mypy
 commands=
     mypy tests/typing


### PR DESCRIPTION
Resolve Dependabot warnings.

Note: flask removed `_request_ctx_stack` and `_app_ctx_stack`, but test is still testing what it was supposed to test, since `request`, `current_app`, `session` and `g` are also `LocalProxy`.