### PR TITLE
Update examples

### DIFF
--- a/docs/tutorials/asyncio-daemon.rst
+++ b/docs/tutorials/asyncio-daemon.rst
@@ -18,7 +18,7 @@ In this tutorial we will use:
 
 - Python 3
 - Docker
-- Docker-compose
+- Docker Compose
 
 Start from the scratch or jump to the section:
 
@@ -47,28 +47,27 @@ response it will log:
 Prerequisites
 -------------
 
-We will use `Docker <https://www.docker.com/>`_ and
-`docker-compose <https://docs.docker.com/compose/>`_ in this tutorial. Let's check the versions:
+We will use `docker compose <https://docs.docker.com/compose/>`_ in this tutorial. Let's check the versions:
 
 .. code-block:: bash
 
    docker --version
-   docker-compose --version
+   docker compose version
 
 The output should look something like:
 
 .. code-block:: bash
 
-   Docker version 20.10.5, build 55c4c88
-   docker-compose version 1.29.0, build 07737305
+   Docker version 27.3.1, build ce12230
+   Docker Compose version v2.29.7
 
 .. note::
 
-   If you don't have ``Docker`` or ``docker-compose`` you need to install them before proceeding.
+   If you don't have ``Docker`` or ``docker compose`` you need to install them before proceeding.
    Follow these installation guides:
 
    - `Install Docker <https://docs.docker.com/get-docker/>`_
-   - `Install docker-compose <https://docs.docker.com/compose/install/>`_
+   - `Install docker compose <https://docs.docker.com/compose/install/>`_
 
 The prerequisites are satisfied. Let's get started with the project layout.
 
@@ -129,13 +128,13 @@ Put next lines into the ``requirements.txt`` file:
    pytest-cov
 
 Second, we need to create the ``Dockerfile``. It will describe the daemon's build process and
-specify how to run it. We will use ``python:3.9-buster`` as a base image.
+specify how to run it. We will use ``python:3.13-bookworm`` as a base image.
 
 Put next lines into the ``Dockerfile`` file:
 
 .. code-block:: bash
 
-   FROM python:3.10-buster
+   FROM python:3.13-bookworm
 
    ENV PYTHONUNBUFFERED=1
 
@@ -155,8 +154,6 @@ Put next lines into the ``docker-compose.yml`` file:
 
 .. code-block:: yaml
 
-   version: "3.7"
-
    services:
 
      monitor:
@@ -171,7 +168,7 @@ Run in the terminal:
 
 .. code-block:: bash
 
-   docker-compose build
+   docker compose build
 
 The build process may take a couple of minutes. You should see something like this in the end:
 
@@ -184,7 +181,7 @@ After the build is done run the container:
 
 .. code-block:: bash
 
-   docker-compose up
+   docker compose up
 
 The output should look like:
 
@@ -461,7 +458,7 @@ Run in the terminal:
 
 .. code-block:: bash
 
-   docker-compose up
+   docker compose up
 
 The output should look like:
 
@@ -705,7 +702,7 @@ Run in the terminal:
 
 .. code-block:: bash
 
-   docker-compose up
+   docker compose up
 
 You should see:
 
@@ -813,7 +810,7 @@ Run in the terminal:
 
 .. code-block:: bash
 
-   docker-compose up
+   docker compose up
 
 You should see:
 
@@ -965,15 +962,16 @@ Run in the terminal:
 
 .. code-block:: bash
 
-   docker-compose run --rm monitor py.test monitoringdaemon/tests.py --cov=monitoringdaemon
+   docker compose run --rm monitor py.test monitoringdaemon/tests.py --cov=monitoringdaemon
 
 You should see:
 
 .. code-block:: bash
 
-   platform linux -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
+   platform linux -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0
    rootdir: /code
-   plugins: asyncio-0.16.0, cov-3.0.0
+   plugins: cov-6.0.0, asyncio-0.24.0
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
    collected 2 items
 
    monitoringdaemon/tests.py ..                                    [100%]

--- a/examples/miniapps/aiohttp/README.rst
+++ b/examples/miniapps/aiohttp/README.rst
@@ -98,8 +98,9 @@ The output should be something like:
 
 .. code-block::
 
-   platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
-   plugins: asyncio-0.16.0, anyio-3.3.4, aiohttp-0.3.0, cov-3.0.0
+   platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0
+   plugins: cov-6.0.0, anyio-4.4.0, asyncio-0.24.0, aiohttp-1.0.5
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
    collected 3 items
 
    giphynavigator/tests.py ...                                     [100%]

--- a/examples/miniapps/aiohttp/giphynavigator/tests.py
+++ b/examples/miniapps/aiohttp/giphynavigator/tests.py
@@ -3,9 +3,13 @@
 from unittest import mock
 
 import pytest
+import pytest_asyncio
 
 from giphynavigator.application import create_app
 from giphynavigator.giphy import GiphyClient
+
+
+pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
@@ -15,9 +19,9 @@ def app():
     app.container.unwire()
 
 
-@pytest.fixture
-def client(app, aiohttp_client, loop):
-    return loop.run_until_complete(aiohttp_client(app))
+@pytest_asyncio.fixture
+async def client(app, aiohttp_client):
+    return await aiohttp_client(app)
 
 
 async def test_index(client, app):

--- a/examples/miniapps/aiohttp/requirements.txt
+++ b/examples/miniapps/aiohttp/requirements.txt
@@ -2,4 +2,5 @@ dependency-injector
 aiohttp
 pyyaml
 pytest-aiohttp
+pytest-asyncio
 pytest-cov

--- a/examples/miniapps/asyncio-daemon/Dockerfile
+++ b/examples/miniapps/asyncio-daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-buster
+FROM python:3.13-bookworm
 
 ENV PYTHONUNBUFFERED=1
 

--- a/examples/miniapps/asyncio-daemon/README.rst
+++ b/examples/miniapps/asyncio-daemon/README.rst
@@ -13,13 +13,13 @@ Build the Docker image:
 
 .. code-block:: bash
 
-   docker-compose build
+   docker compose build
 
 Run the docker-compose environment:
 
 .. code-block:: bash
 
-    docker-compose up
+    docker compose up
 
 The output should be something like:
 
@@ -59,15 +59,16 @@ To run the tests do:
 
 .. code-block:: bash
 
-   docker-compose run --rm monitor py.test monitoringdaemon/tests.py --cov=monitoringdaemon
+   docker compose run --rm monitor py.test monitoringdaemon/tests.py --cov=monitoringdaemon
 
 The output should be something like:
 
 .. code-block::
 
-   platform linux -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
+   platform linux -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0
    rootdir: /code
-   plugins: asyncio-0.16.0, cov-3.0.0
+   plugins: cov-6.0.0, asyncio-0.24.0
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
    collected 2 items
 
    monitoringdaemon/tests.py ..                                    [100%]

--- a/examples/miniapps/asyncio-daemon/monitoringdaemon/tests.py
+++ b/examples/miniapps/asyncio-daemon/monitoringdaemon/tests.py
@@ -61,7 +61,7 @@ async def test_example_monitor(container, caplog):
 
 
 @pytest.mark.asyncio
-async def test_dispatcher(container, caplog, event_loop):
+async def test_dispatcher(container, caplog):
     caplog.set_level("INFO")
 
     example_monitor_mock = mock.AsyncMock()
@@ -72,6 +72,7 @@ async def test_dispatcher(container, caplog, event_loop):
             httpbin_monitor=httpbin_monitor_mock,
     ):
         dispatcher = container.dispatcher()
+        event_loop = asyncio.get_running_loop()
         event_loop.create_task(dispatcher.start())
         await asyncio.sleep(0.1)
         dispatcher.stop()

--- a/examples/miniapps/fastapi-redis/Dockerfile
+++ b/examples/miniapps/fastapi-redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-buster
+FROM python:3.13-bookworm
 
 ENV PYTHONUNBUFFERED=1
 

--- a/examples/miniapps/fastapi-redis/README.rst
+++ b/examples/miniapps/fastapi-redis/README.rst
@@ -12,13 +12,13 @@ Build the Docker image:
 
 .. code-block:: bash
 
-   docker-compose build
+   docker compose build
 
 Run the docker-compose environment:
 
 .. code-block:: bash
 
-    docker-compose up
+    docker compose up
 
 The output should be something like:
 
@@ -54,16 +54,16 @@ To run the tests do:
 
 .. code-block:: bash
 
-   docker-compose run --rm example py.test fastapiredis/tests.py --cov=fastapiredis
+   docker compose run --rm example py.test fastapiredis/tests.py --cov=fastapiredis
 
 The output should be something like:
 
 .. code-block::
 
-   platform linux -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
+   platform linux -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0
    rootdir: /code
-   plugins: cov-4.0.0, asyncio-0.20.3
-   collected 1 item
+   plugins: cov-6.0.0, asyncio-0.24.0, anyio-4.7.0
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
 
    fastapiredis/tests.py .                                         [100%]
 

--- a/examples/miniapps/fastapi-redis/fastapiredis/redis.py
+++ b/examples/miniapps/fastapi-redis/fastapiredis/redis.py
@@ -1,6 +1,6 @@
 from typing import AsyncIterator
 
-from aioredis import from_url, Redis
+from redis.asyncio import from_url, Redis
 
 
 async def init_redis_pool(host: str, password: str) -> AsyncIterator[Redis]:

--- a/examples/miniapps/fastapi-redis/fastapiredis/services.py
+++ b/examples/miniapps/fastapi-redis/fastapiredis/services.py
@@ -1,6 +1,6 @@
 """Services module."""
 
-from aioredis import Redis
+from redis.asyncio import Redis
 
 
 class Service:

--- a/examples/miniapps/fastapi-redis/requirements.txt
+++ b/examples/miniapps/fastapi-redis/requirements.txt
@@ -1,7 +1,7 @@
 dependency-injector
 fastapi
 uvicorn
-aioredis
+redis>=4.2
 
 # For testing:
 pytest

--- a/examples/miniapps/fastapi-simple/tests.py
+++ b/examples/miniapps/fastapi-simple/tests.py
@@ -1,13 +1,14 @@
 from unittest import mock
 
 import pytest
+import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from fastapi_di_example import app, container, Service
 
 
-@pytest.fixture
-async def client(event_loop):
+@pytest_asyncio.fixture
+async def client():
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test",

--- a/examples/miniapps/fastapi-sqlalchemy/Dockerfile
+++ b/examples/miniapps/fastapi-sqlalchemy/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-buster
+FROM python:3.13-bookworm
 
 ENV PYTHONUNBUFFERED=1
 ENV HOST=0.0.0.0

--- a/examples/miniapps/fastapi-sqlalchemy/README.rst
+++ b/examples/miniapps/fastapi-sqlalchemy/README.rst
@@ -15,13 +15,13 @@ Build the Docker image:
 
 .. code-block:: bash
 
-   docker-compose build
+   docker compose build
 
 Run the docker-compose environment:
 
 .. code-block:: bash
 
-    docker-compose up
+    docker compose up
 
 The output should be something like:
 
@@ -67,15 +67,15 @@ To run the tests do:
 
 .. code-block:: bash
 
-   docker-compose run --rm webapp py.test webapp/tests.py --cov=webapp
+   docker compose run --rm webapp py.test webapp/tests.py --cov=webapp
 
 The output should be something like:
 
 .. code-block::
 
-   platform linux -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
+   platform linux -- Python 3.13.1, pytest-8.3.4, pluggy-1.5.0
    rootdir: /code
-   plugins: cov-3.0.0
+   plugins: cov-6.0.0, anyio-4.7.0
    collected 7 items
 
    webapp/tests.py .......                                         [100%]

--- a/examples/miniapps/fastapi-sqlalchemy/requirements.txt
+++ b/examples/miniapps/fastapi-sqlalchemy/requirements.txt
@@ -1,5 +1,5 @@
 dependency-injector
-fastapi
+fastapi[standard]
 uvicorn
 pyyaml
 sqlalchemy

--- a/examples/miniapps/fastapi/README.rst
+++ b/examples/miniapps/fastapi/README.rst
@@ -101,9 +101,9 @@ The output should be something like:
 
 .. code-block::
 
-   platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
-   plugins: asyncio-0.16.0, cov-3.0.0
-   collected 3 items
+   platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0
+   plugins: cov-6.0.0, anyio-4.4.0, asyncio-0.24.0, aiohttp-1.0.5
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
 
    giphynavigator/tests.py ...                                     [100%]
 

--- a/examples/miniapps/fastapi/giphynavigator/tests.py
+++ b/examples/miniapps/fastapi/giphynavigator/tests.py
@@ -3,13 +3,14 @@
 from unittest import mock
 
 import pytest
+import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from giphynavigator.application import app
 from giphynavigator.giphy import GiphyClient
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def client():
     async with AsyncClient(
         transport=ASGITransport(app=app),

--- a/examples/miniapps/flask-blueprints/README.rst
+++ b/examples/miniapps/flask-blueprints/README.rst
@@ -81,8 +81,9 @@ The output should be something like:
 
 .. code-block::
 
-   platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
-   plugins: cov-3.0.0, flask-1.2.0
+   platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0
+   plugins: cov-6.0.0, flask-1.3.0
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
    collected 2 items
 
    githubnavigator/tests.py ..                                     [100%]

--- a/examples/miniapps/flask-blueprints/githubnavigator/application.py
+++ b/examples/miniapps/flask-blueprints/githubnavigator/application.py
@@ -1,7 +1,7 @@
 """Application module."""
 
 from flask import Flask
-from flask_bootstrap import Bootstrap
+from flask_bootstrap import Bootstrap4
 
 from .containers import Container
 from .blueprints import example
@@ -15,7 +15,7 @@ def create_app() -> Flask:
     app.container = container
     app.register_blueprint(example.blueprint)
 
-    bootstrap = Bootstrap()
+    bootstrap = Bootstrap4()
     bootstrap.init_app(app)
 
     return app

--- a/examples/miniapps/flask/README.rst
+++ b/examples/miniapps/flask/README.rst
@@ -81,8 +81,9 @@ The output should be something like:
 
 .. code-block::
 
-   platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
-   plugins: cov-3.0.0, flask-1.2.0
+   platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0
+   plugins: cov-6.0.0, flask-1.3.0
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
    collected 2 items
 
    githubnavigator/tests.py ..                                     [100%]

--- a/examples/miniapps/flask/githubnavigator/application.py
+++ b/examples/miniapps/flask/githubnavigator/application.py
@@ -1,7 +1,7 @@
 """Application module."""
 
 from flask import Flask
-from flask_bootstrap import Bootstrap
+from flask_bootstrap import Bootstrap4
 
 from .containers import Container
 from . import views
@@ -15,7 +15,7 @@ def create_app() -> Flask:
     app.container = container
     app.add_url_rule("/", "index", views.index)
 
-    bootstrap = Bootstrap()
+    bootstrap = Bootstrap4()
     bootstrap.init_app(app)
 
     return app

--- a/examples/miniapps/movie-lister/README.rst
+++ b/examples/miniapps/movie-lister/README.rst
@@ -58,8 +58,8 @@ The output should be something like:
 
 .. code-block::
 
-   platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
-   plugins: cov-3.0.0
+   platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0
+   plugins: cov-6.0.0
    collected 2 items
 
    movies/tests.py ..                                              [100%]

--- a/examples/miniapps/sanic/README.rst
+++ b/examples/miniapps/sanic/README.rst
@@ -27,7 +27,7 @@ To run the application do:
 .. code-block:: bash
 
     export GIPHY_API_KEY=wBJ2wZG7SRqfrU9nPgPiWvORmloDyuL0
-    python -m giphynavigator
+    sanic giphynavigator.application:create_app
 
 The output should be something like:
 
@@ -98,8 +98,9 @@ The output should be something like:
 
 .. code-block::
 
-   platform darwin -- Python 3.10.0, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
-   plugins: sanic-1.9.1, anyio-3.3.4, cov-3.0.0
+   platform linux -- Python 3.12.3, pytest-8.3.2, pluggy-1.5.0
+   plugins: cov-6.0.0, anyio-4.4.0, asyncio-0.24.0
+   asyncio: mode=Mode.STRICT, default_loop_scope=None
    collected 3 items
 
    giphynavigator/tests.py ...                                     [100%]

--- a/examples/miniapps/sanic/requirements.txt
+++ b/examples/miniapps/sanic/requirements.txt
@@ -1,6 +1,6 @@
 dependency-injector
-sanic<=21.6
+sanic
+sanic-testing
 aiohttp
 pyyaml
-pytest-sanic
 pytest-cov


### PR DESCRIPTION
As title says, now all the miniapps should be runnable with latest version of respective dependencies.

Note: Docker Compose is now shipped with base Docker version, so doc is updated to account this fact.