### PR TITLE
:art: Raise exception instead of hiding it in finally

### DIFF
--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -3221,8 +3221,8 @@ cdef class ThreadLocalSingleton(BaseSingleton):
                 return future_result
 
             self._storage.instance = instance
-        finally:
-            return instance
+        
+        return instance
 
     def _async_init_instance(self, future_result, result):
         try:

--- a/tests/unit/providers/singleton/test_thread_local_singleton_py3.py
+++ b/tests/unit/providers/singleton/test_thread_local_singleton_py3.py
@@ -1,0 +1,20 @@
+import pytest
+
+from dependency_injector.containers import Container
+from dependency_injector.providers import ThreadLocalSingleton
+
+
+class FailingClass:
+    def __init__(self):
+        raise ValueError("FAILING CLASS")
+
+
+class TestContainer(Container):
+    failing_class = ThreadLocalSingleton(FailingClass)
+
+
+def test_on_failure_value_error_is_raised():
+    container = TestContainer()
+
+    with pytest.raises(ValueError, match="FAILING CLASS"):
+        container.failing_class()


### PR DESCRIPTION
We use the dependency-injector a lot in our private project. Currently, when the configuration of the ThreadLocalSingleton is invalid (i.e. a constructor argument is forgotten), the library prints only this exception:

```
UnboundLocalError: local variable 'instance' referenced before assignment
```

This is really frustrating, because it provides no leads to the actual error. At the company, for last 7 months, we use a fork of this library, https://github.com/gortibaldik/dependency-injector-fg with a separate PyPI repo. However as we see that this project is again maintained, we would like to merge this small PR, which solves approx 50% of all of our problems with the library (the other 50% are issues with wiring which stem from our misunderstandings... :grinning: ).