### PR TITLE
Migrate CI pipeline to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -49,8 +49,9 @@ jobs:
       - run: |
           python -m pip install --upgrade build
           python -m build --sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-sdist
           path: ./dist/*
 
   build-wheels:
@@ -66,8 +67,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-x86-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   build-wheels-linux-aarch64:
@@ -85,8 +87,9 @@ jobs:
         uses: pypa/cibuildwheel@v2.20.0
         env:
           CIBW_ARCHS_LINUX: aarch64
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: cibw-wheels-arm-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   publish:
@@ -94,10 +97,11 @@ jobs:
     needs: [build-sdist, build-wheels, build-wheels-linux-aarch64]
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
`actions/upload-artifact@v3` will be EOL-ed in [January 30, 2025](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#artifacts-v3-brownouts). Upgrade our publishing pipeline according to [official migration guidelines](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md). Changes are based on https://github.com/pypa/cibuildwheel/commit/2c4974286fe784b47c157b64a6c61a229b9935ee