### PR TITLE
Native GHA ARM runners

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, windows-2019, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-14]
     env:
       CIBW_SKIP: cp27-*
     steps:
@@ -72,29 +72,9 @@ jobs:
           name: cibw-wheels-x86-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
-  build-wheels-linux-aarch64:
-    name: Build wheels (ubuntu-24.04-aarch64)
-    needs: [tests, linters]
-    runs-on: ubuntu-24.04
-    env:
-      CIBW_SKIP: cp27-*
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
-        env:
-          CIBW_ARCHS_LINUX: aarch64
-      - uses: actions/upload-artifact@v4
-        with:
-          name: cibw-wheels-arm-${{ matrix.os }}-${{ strategy.job-index }}
-          path: ./wheelhouse/*.whl
-
   publish:
     name: Publish on PyPI
-    needs: [build-sdist, build-wheels, build-wheels-linux-aarch64]
+    needs: [build-sdist, build-wheels]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -10,7 +10,7 @@ jobs:
 
   tests:
     name: Run tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -23,7 +23,7 @@ jobs:
 
   linters:
     name: Run linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         toxenv: [flake8, pydocstyle, mypy, pylint]
@@ -40,7 +40,7 @@ jobs:
   build-sdist:
     name: Build source tarball
     needs: [tests, linters]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2019, macos-14]
+        os: [ubuntu-24.04, windows-2019, macos-14]
     env:
       CIBW_SKIP: cp27-*
     steps:
@@ -73,9 +73,9 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build-wheels-linux-aarch64:
-    name: Build wheels (ubuntu-22.04-aarch64)
+    name: Build wheels (ubuntu-24.04-aarch64)
     needs: [tests, linters]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CIBW_SKIP: cp27-*
     steps:
@@ -95,7 +95,7 @@ jobs:
   publish:
     name: Publish on PyPI
     needs: [build-sdist, build-wheels, build-wheels-linux-aarch64]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -113,7 +113,7 @@ jobs:
   publish-docs:
     name: Publish docs
     needs: [publish]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
ARM images are [now officially available for opensource repos](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/). Use these images instead of spinning up QEMU. This change will significantly improve our publishing pipeline times.

Also updated ubuntu image versions to match ones from `tests-and-linters.yml`.