### PR TITLE
Remove unused root property from ConfigurationOption

### DIFF
--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -1592,8 +1592,7 @@ cdef class ConfigurationOption(Provider):
             segment() if is_provider(segment) else segment for segment in self._name
         )
 
-    @property
-    def root(self):
+    def _get_root(self):
         return self._root
 
     def get_name(self):

--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -314,7 +314,7 @@ class ProvidersMap:
         original: providers.ConfigurationOption,
         as_: Any = None,
     ) -> Optional[providers.Provider]:
-        original_root = original.root
+        original_root = original._get_root()
         new = self._resolve_provider(original_root)
         if new is None:
             return None


### PR DESCRIPTION
Replace `ConfigurationOption`'s `root` property with a method `_get_root` to avoid name collisions as described in #874.