### PR TITLE
Signature cache optimization

### DIFF
--- a/src/dependency_injector/wiring.py
+++ b/src/dependency_injector/wiring.py
@@ -594,7 +594,7 @@ def _extract_marker(parameter: inspect.Parameter) -> Optional["_Marker"]:
 _signature_cache: Dict[int, Tuple[Dict[str, Any], Dict[str, Any]]] = {}
 
 
-def _fetch_reference_injections(
+def _fetch_reference_injections(  # noqa: C901
     fn: Callable[..., Any],
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """Get reference injections with caching."""
@@ -639,7 +639,6 @@ def _fetch_reference_injections(
 
         injections[parameter_name] = marker
 
-    # Cache the result
     result = (injections, closing)
     _signature_cache[fn_id] = result
     return result


### PR DESCRIPTION
I had a single endpoints.py file with all my endpoints in it, but it got to be unmaintainable. The problem is that wiring went from ~1 sec to ~2.5 on my MacBook Pro M2! No logic changed.

I dug in and it seems that the _fetch_reference_injections doesn't do any caching and this is an expensive operation. I'm a bit unclear why it would be scanning things multiple times though? I added some caching and this bumped by performance back to do pre-file split speeds. 

I'll admit I used Claude to help me do this as I'm not super up to speed on the codebase nor the ins and outs of the inspect module, but the overall change makes sense to me. 

Thoughts?