### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -4,28 +4,12 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
 
-  tests-on-legacy-versions:
-    name: Run tests on legacy versions
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: [3.7]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - run: pip install tox
-      - run: tox
-        env:
-          TOXENV: ${{ matrix.python-version }}
-
   test-on-different-versions:
     name: Run tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ maintainers = [
 description = "Dependency injection framework for Python"
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = {file = "LICENSE.rst", content-type = "text/x-rst"}
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = [
     "Dependency injection",
     "DI",
@@ -31,7 +31,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 
 import asyncio
 import builtins
-import contextvars
 import copy
 import errno
 import functools
@@ -17,6 +16,7 @@ import sys
 import threading
 import warnings
 from configparser import ConfigParser as IniConfigParser
+from contextvars import ContextVar
 
 try:
     from inspect import _is_coroutine_mark as _is_coroutine_marker
@@ -3224,15 +3224,10 @@ cdef class ContextLocalSingleton(BaseSingleton):
         :param provides: Provided type.
         :type provides: type
         """
-        if not contextvars:
-            raise RuntimeError(
-                "Contextvars library not found. This provider "
-                "requires Python 3.7 or a backport of contextvars. "
-                "To install a backport run \"pip install contextvars\"."
-            )
+
 
         super(ContextLocalSingleton, self).__init__(provides, *args, **kwargs)
-        self._storage = contextvars.ContextVar("_storage", default=self._none)
+        self._storage = ContextVar("_storage", default=self._none)
 
     def reset(self):
         """Reset cached instance, if any.

--- a/tests/unit/providers/resource/test_async_resource_py35.py
+++ b/tests/unit/providers/resource/test_async_resource_py35.py
@@ -34,7 +34,6 @@ async def test_init_async_function():
 
 
 @mark.asyncio
-@mark.skipif(sys.version_info < (3, 6), reason="requires Python 3.6+")
 async def test_init_async_generator():
     resource = object()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 parallel_show_output = true
 envlist=
-    coveralls, pylint, flake8, pydocstyle, pydantic-v1, pydantic-v2, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy3.9, pypy3.10
+    coveralls, pylint, flake8, pydocstyle, pydantic-v1, pydantic-v2, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy3.9, pypy3.10
 
 [testenv]
 deps=


### PR DESCRIPTION
* GitHub Actions has [dropped support](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#ubuntu-20-image-is-closing-down) for Ubuntu 20.04, so we no longer able run test for legacy Python versions.
* Python 3.7 was EOL-ed for about 2 years by now.