### PR TITLE
Update Cython to v3.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cython==3.0.11
+cython==3.1.0
 setuptools
 pytest
 pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ from Cython.Compiler import Options
 from setuptools import Extension, setup
 
 debug = os.environ.get("DEPENDENCY_INJECTOR_DEBUG_MODE") == "1"
+limited_api = os.environ.get("DEPENDENCY_INJECTOR_LIMITED_API") == "1"
 defined_macros = []
+options = {}
 compiler_directives = {
     "language_level": 3,
     "profile": debug,
@@ -17,6 +19,7 @@ Options.annotate = debug
 
 # Adding debug options:
 if debug:
+    limited_api = False  # line tracing is not part of the Limited API
     defined_macros.extend(
         [
             ("CYTHON_TRACE", "1"),
@@ -25,14 +28,20 @@ if debug:
         ]
     )
 
+if limited_api:
+    options.setdefault("bdist_wheel", {})
+    options["bdist_wheel"]["py_limited_api"] = "cp38"
+    defined_macros.append(("Py_LIMITED_API", 0x03080000))
 
 setup(
+    options=options,
     ext_modules=cythonize(
         [
             Extension(
                 "*",
                 ["src/**/*.pyx"],
                 define_macros=defined_macros,
+                py_limited_api=limited_api,
             ),
         ],
         annotate=debug,


### PR DESCRIPTION
Also add initial support for ABI3 builds (Limited API).