### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -75,10 +75,13 @@ jobs:
           name: cibw-wheels-x86-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
-  publish:
-    name: Publish on PyPI
+  test-publish:
+    name: Upload release to TestPyPI
     needs: [build-sdist, build-wheels]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
+    environment: test-pypi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -87,11 +90,22 @@ jobs:
           merge-multiple: true
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-#           For publishing to Test PyPI, uncomment next two lines:
-#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
+
+  publish:
+    name: Upload release to PyPI
+    needs: [build-sdist, build-wheels, test-publish]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-docs:
     name: Publish docs

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -62,11 +62,14 @@ jobs:
       matrix:
         os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2019, macos-14]
     env:
-      CIBW_SKIP: cp27-*
+      CIBW_ENABLE: pypy
+      CIBW_ENVIRONMENT: >-
+        PIP_CONFIG_SETTINGS="build_ext=-j4"
+        DEPENDENCY_INJECTOR_LIMITED_API="1"
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.20.0
+        uses: pypa/cibuildwheel@v2.23.3
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-x86-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -18,6 +18,7 @@ jobs:
       - run: pip install tox
       - run: tox
         env:
+          DEPENDENCY_INJECTOR_LIMITED_API: 1
           TOXENV: ${{ matrix.python-version }}
 
   test-different-pydantic-versions:

--- a/.github/workflows/tests-and-linters.yml
+++ b/.github/workflows/tests-and-linters.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.12
-      - run: pip install tox 'cython>=3,<4'
+      - run: pip install tox
       - run: tox -vv
         env:
           TOXENV: coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ lib64/
 parts/
 sdist/
 var/
+wheelhouse/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,7 @@
-recursive-include src/dependency_injector *.py* *.c
+recursive-include src/dependency_injector *.py* *.c py.typed
 recursive-include tests *.py
 include README.rst
 include CONTRIBUTORS.rst
 include LICENSE.rst
-include requirements.txt
 include setup.py
 include tox.ini
-include py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "Cython"]
+requires = ["setuptools", "Cython>=3.1.1"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ max-public-methods = 30
 [tool.pytest.ini_options]
 testpaths = ["tests/unit/"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 markers = [
     "pydantic: Tests with Pydantic as a dependency",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-cython==3.1.0
+cython==3.1.1
 setuptools
 pytest
 pytest-asyncio
@@ -13,7 +13,8 @@ mypy
 pyyaml
 httpx
 fastapi
-pydantic==1.10.17
+pydantic
+pydantic-settings
 numpy
 scipy
 boto3

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,17 @@
 """`Dependency injector` setup script."""
 
 import os
+import sys
 
 from Cython.Build import cythonize
 from Cython.Compiler import Options
 from setuptools import Extension, setup
 
 debug = os.environ.get("DEPENDENCY_INJECTOR_DEBUG_MODE") == "1"
-limited_api = os.environ.get("DEPENDENCY_INJECTOR_LIMITED_API") == "1"
+limited_api = (
+    os.environ.get("DEPENDENCY_INJECTOR_LIMITED_API") == "1"
+    and sys.implementation.name == "cpython"
+)
 defined_macros = []
 options = {}
 compiler_directives = {
@@ -31,7 +35,7 @@ if debug:
 if limited_api:
     options.setdefault("bdist_wheel", {})
     options["bdist_wheel"]["py_limited_api"] = "cp38"
-    defined_macros.append(("Py_LIMITED_API", 0x03080000))
+    defined_macros.append(("Py_LIMITED_API", "0x03080000"))
 
 setup(
     options=options,

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 parallel_show_output = true
 envlist=
-    coveralls, pylint, flake8, pydocstyle, pydantic-v1, pydantic-v2, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy3.9, pypy3.10
+    coveralls, pylint, flake8, pydocstyle, pydantic-v1, pydantic-v2, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, pypy3.9, pypy3.10, pypy3.11
 
 [testenv]
 deps=
@@ -20,7 +20,6 @@ deps=
 extras=
     yaml
 commands = pytest
-python_files = test_*_py3*.py
 setenv =
     COVERAGE_RCFILE = pyproject.toml
 
@@ -60,22 +59,6 @@ commands=
     coverage run -m pytest
     coverage report
     coveralls
-
-[testenv:pypy3.9]
-deps=
-    pytest
-    pytest-asyncio
-    httpx
-    flask
-    pydantic-settings
-    werkzeug
-    fastapi
-    boto3
-    mypy_boto3_s3
-extras=
-    yaml
-commands = pytest
-
 
 [testenv:pylint]
 deps=


### PR DESCRIPTION
Fix some warnings, but more importantly - migrate to ABI3 wheels for CPython. This reduces build time from 1h+ to ~16m + 5x times size reduction (fixes #487).