### PR TITLE
Use cache in _fetch_reference_injections()

### DIFF
--- a/src/dependency_injector/containers.pyi
+++ b/src/dependency_injector/containers.pyi
@@ -30,12 +30,14 @@ class WiringConfiguration:
     packages: List[Any]
     from_package: Optional[str]
     auto_wire: bool
+    keep_cache: bool
     def __init__(
         self,
         modules: Optional[Iterable[Any]] = None,
         packages: Optional[Iterable[Any]] = None,
         from_package: Optional[str] = None,
         auto_wire: bool = True,
+        keep_cache: bool = False,
     ) -> None: ...
 
 class Container:

--- a/src/dependency_injector/containers.pyx
+++ b/src/dependency_injector/containers.pyx
@@ -20,14 +20,15 @@ from .wiring import wire, unwire
 class WiringConfiguration:
     """Container wiring configuration."""
 
-    def __init__(self, modules=None, packages=None, from_package=None, auto_wire=True):
+    def __init__(self, modules=None, packages=None, from_package=None, auto_wire=True, keep_cache=False):
         self.modules = [*modules] if modules else []
         self.packages = [*packages] if packages else []
         self.from_package = from_package
         self.auto_wire = auto_wire
+        self.keep_cache = keep_cache
 
     def __deepcopy__(self, memo=None):
-        return self.__class__(self.modules, self.packages, self.from_package, self.auto_wire)
+        return self.__class__(self.modules, self.packages, self.from_package, self.auto_wire, self.keep_cache)
 
 
 class Container:
@@ -258,7 +259,7 @@ class DynamicContainer(Container):
         """Check if auto wiring is needed."""
         return self.wiring_config.auto_wire is True
 
-    def wire(self, modules=None, packages=None, from_package=None):
+    def wire(self, modules=None, packages=None, from_package=None, keep_cache=None):
         """Wire container providers with provided packages and modules.
 
         :rtype: None
@@ -289,10 +290,14 @@ class DynamicContainer(Container):
         if not modules and not packages:
             return
 
+        if keep_cache is None:
+            keep_cache = self.wiring_config.keep_cache
+
         wire(
             container=self,
             modules=modules,
             packages=packages,
+            keep_cache=keep_cache,
         )
 
         if modules:

--- a/tests/unit/wiring/test_cache.py
+++ b/tests/unit/wiring/test_cache.py
@@ -1,0 +1,46 @@
+"""Tests for string module and package names."""
+
+from typing import Iterator, Optional
+
+from pytest import fixture, mark
+from samples.wiring.container import Container
+
+from dependency_injector.wiring import _fetch_reference_injections
+
+
+@fixture
+def container() -> Iterator[Container]:
+    container = Container()
+    yield container
+    container.unwire()
+
+
+@mark.parametrize(
+    ["arg_value", "wc_value", "empty_cache"],
+    [
+        (None, False, True),
+        (False, True, True),
+        (True, False, False),
+        (None, True, False),
+    ],
+)
+def test_fetch_reference_injections_cache(
+    container: Container,
+    arg_value: Optional[bool],
+    wc_value: bool,
+    empty_cache: bool,
+) -> None:
+    container.wiring_config.keep_cache = wc_value
+    container.wire(
+        modules=["samples.wiring.module"],
+        packages=["samples.wiring.package"],
+        keep_cache=arg_value,
+    )
+    cache_info = _fetch_reference_injections.cache_info()
+
+    if empty_cache:
+        assert cache_info == (0, 0, None, 0)
+    else:
+        assert cache_info.hits > 0
+        assert cache_info.misses > 0
+        assert cache_info.currsize > 0


### PR DESCRIPTION
Evolution of the idea from PR #880, but slightly more controllable in terms of cache management. Unlike #880, cache is discarded by default after each `wire()`, but for multi-container use cases there is a flag to preserve cache + helper function to manually clear it.