### PR TITLE
Fix providers.Resource missing overloads for AbstractContextManager and AbstractAsyncContextManager

### DIFF
--- a/src/dependency_injector/providers.pyi
+++ b/src/dependency_injector/providers.pyi
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import AbstractContextManager, AbstractAsyncContextManager
 from pathlib import Path
 from typing import (
     Awaitable,
@@ -461,6 +462,20 @@ class Resource(Provider[T]):
     def __init__(
         self,
         provides: Optional[Type[resources.AsyncResource[T]]] = None,
+        *args: Injection,
+        **kwargs: Injection,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        provides: Optional[_Callable[..., AbstractContextManager[T]]] = None,
+        *args: Injection,
+        **kwargs: Injection,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        provides: Optional[_Callable[..., AbstractAsyncContextManager[T]]] = None,
         *args: Injection,
         **kwargs: Injection,
     ) -> None: ...

--- a/tests/typing/resource.py
+++ b/tests/typing/resource.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager, asynccontextmanager
 from typing import (
     Any,
     AsyncGenerator,
@@ -7,6 +8,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Self,
 )
 
 from dependency_injector import providers, resources
@@ -109,3 +111,62 @@ async def _provide8() -> None:
 # Test 9: to check string imports
 provider9: providers.Resource[Dict[Any, Any]] = providers.Resource("builtins.dict")
 provider9.set_provides("builtins.dict")
+
+
+# Test 10: to check the return type with classes implementing AbstractContextManager protocol
+class MyResource10:
+    def __init__(self) -> None:
+        pass
+    
+    def __enter__(self) -> Self:
+        return self
+    
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+provider10 = providers.Resource(MyResource10)
+var10: MyResource10 = provider10()
+
+
+# Test 11: to check the return type with functions decorated with contextlib.contextmanager
+@contextmanager
+def init11() -> Iterator[int]:
+    yield 1
+
+
+provider11 = providers.Resource(init11)
+var11: int = provider11()
+
+
+# Test 12: to check the return type with classes implementing AbstractAsyncContextManager protocol
+class MyResource12:
+    def __init__(self) -> None:
+        pass
+    
+    async def __aenter__(self) -> Self:
+        return self
+    
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+provider12 = providers.Resource(MyResource12)
+
+
+async def _provide12() -> None:
+    var1: MyResource12 = await provider12()  # type: ignore
+    var2: MyResource12 = await provider12.async_()
+
+
+# Test 13: to check the return type with functions decorated with contextlib.asynccontextmanager
+@asynccontextmanager
+async def init13() -> AsyncIterator[int]:
+    yield 1
+
+
+provider13 = providers.Resource(init13)
+
+async def _provide13() -> None:
+    var1: int = await provider13()  # type: ignore
+    var2: int = await provider13.async_()


### PR DESCRIPTION
Addresses #926

---

Demo

```python
# main.py

import asyncio
from collections.abc import AsyncIterator, Iterator
from contextlib import asynccontextmanager, contextmanager
from typing import reveal_type

from dependency_injector import containers, providers


@contextmanager
def _get_my_int() -> Iterator[int]:
    yield 1


@asynccontextmanager
async def _a_get_my_int() -> AsyncIterator[int]:
    yield 1


class Container(containers.DeclarativeContainer):
    get_my_int = providers.Resource(_get_my_int)
    a_get_my_int = providers.Resource(_a_get_my_int)


async def main() -> None:
    container = Container()
    my_int = container.get_my_int()
    reveal_type(my_int)

    a_my_int = await container.a_get_my_int.async_()
    reveal_type(a_my_int)


if __name__ == "__main__":
    asyncio.run(main())

````

Runtime:
```
python main.py
Runtime type is 'int'
Runtime type is 'int'
```

Mypy output before changing stubs
```
mypy main.py
main.py:29: note: Revealed type is "contextlib._GeneratorContextManager[builtins.int, None, None]"
main.py:32: note: Revealed type is "contextlib._AsyncGeneratorContextManager[builtins.int, None]"
```


Mypy output after changing stubs
```
mypy main.py
main.py:29: note: Revealed type is "builtins.int"
main.py:32: note: Revealed type is "builtins.int"
```