### PR TITLE
Allow `Annotated` marker to be anywhere in the annotation list.

### DIFF
--- a/tests/unit/samples/wiring/module_annotated.py
+++ b/tests/unit/samples/wiring/module_annotated.py
@@ -124,3 +124,10 @@ def test_class_decorator(service: Annotated[Service, Provide[Container.service]]
 
 def test_container(container: Annotated[Container, Provide[Container]]):
     return container.service()
+
+
+@inject
+def test_annotated_with_non_di_metadata_first(
+    service: Annotated[Service, "some other annotated value", Provide[Container.service]],
+):
+    return service

--- a/tests/unit/wiring/provider_ids/test_main_annotated_py36.py
+++ b/tests/unit/wiring/provider_ids/test_main_annotated_py36.py
@@ -174,3 +174,14 @@ def test_class_decorator():
 def test_container():
     service = module.test_container()
     assert isinstance(service, Service)
+
+
+def test_annotated_with_non_di_metadata_first():
+    """Test that Annotated works when DI marker is not the first metadata item.
+
+    This tests the case where Annotated has other metadata (like docstrings or
+    other annotations) before the Provide marker, e.g.:
+        Annotated[Service, "some doc", Provide[Container.service]]
+    """
+    service = module.test_annotated_with_non_di_metadata_first()
+    assert isinstance(service, Service)


### PR DESCRIPTION
There are some situations where multiple libraries/frameworks are inspecting `Annotated` types. For example, the following example code using the [Cyclopts](https://github.com/BrianPugh/cyclopts) CLI library:

```python
from dependency_injector.wiring import Provide, inject
from cyclopts import Parameter

@app.default
@inject
def main(
    name: str,
    *,
    greeting_service: Annotated[GreetingService, Provide[Container.greeting_service], Parameter(parse=False)],
):
    ...
```

Currently, `dependency_injector` [is only looking at the first annotation](https://github.com/ets-labs/python-dependency-injector/blob/5a1aef920372da6a95d14865caab10061aea7104/src/dependency_injector/wiring.py#L677). This PR updates the logic to use the **first valid extracted marker**. This way, the `dependency_injector` marker no longer has to be the first annotated element.

Issue that brought this up: https://github.com/BrianPugh/cyclopts/issues/704