### PR TITLE
Fix required configuration option cache invalidation

### DIFF
--- a/src/dependency_injector/providers.pxd
+++ b/src/dependency_injector/providers.pxd
@@ -117,6 +117,7 @@ cdef class ConfigurationOption(Provider):
     cdef Configuration _root
     cdef dict _children
     cdef bint _required
+    cdef object _required_option
     cdef object _cache
 
 

--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -1522,6 +1522,7 @@ cdef class ConfigurationOption(Provider):
         self._root = root
         self._children = {}
         self._required = required
+        self._required_option = None
         self._cache = UNDEFINED
         super().__init__()
 
@@ -1537,6 +1538,7 @@ cdef class ConfigurationOption(Provider):
         copied._root = deepcopy(self._root, memo)
         copied._children = deepcopy(self._children, memo)
         copied._required = self._required
+        copied._required_option = deepcopy(self._required_option, memo)
         self._copy_overridings(copied, memo)
         return copied
 
@@ -1604,7 +1606,11 @@ cdef class ConfigurationOption(Provider):
         return TypedConfigurationOption(callback, self, *args, **kwargs)
 
     def required(self):
-        return self.__class__(self._name, self._root, required=True)
+        if self._required:
+            return self
+        if self._required_option is None:
+            self._required_option = self.__class__(self._name, self._root, required=True)
+        return self._required_option
 
     def is_required(self):
         return self._required
@@ -1625,6 +1631,9 @@ cdef class ConfigurationOption(Provider):
 
         for provider in self._children.values():
             provider.reset_cache()
+
+        if self._required_option is not None:
+            self._required_option.reset_cache()
 
         for provider in self.overrides:
             if isinstance(provider, (Configuration, ConfigurationOption)):

--- a/tests/unit/providers/configuration/test_config_py2_py3.py
+++ b/tests/unit/providers/configuration/test_config_py2_py3.py
@@ -121,6 +121,24 @@ def test_required(config):
         provider()
 
 
+def test_required_cache_is_reset_after_option_override():
+    class Container(containers.DeclarativeContainer):
+        config = providers.Configuration()
+        singleton = providers.Singleton(dict, value=config.a.required())
+
+    container = Container()
+    container.config.a.from_value("initial")
+
+    assert container.singleton() == {"value": "initial"}
+
+    with container.config.a.override("overridden"):
+        container.singleton.reset()
+        assert container.singleton() == {"value": "overridden"}
+
+    container.singleton.reset()
+    assert container.singleton() == {"value": "initial"}
+
+
 def test_required_defined_none(config):
     provider = providers.Callable(
         lambda value: value,


### PR DESCRIPTION
## Summary

Make a configuration option reuse and track its derived `.required()` provider so configuration cache resets also invalidate the required view.

Fixes #954.

## Root cause and approach

`ConfigurationOption.required()` created a detached provider each time. After that provider resolved a value, the original option had no reference to its cache. An override correctly reset the root/original option tree, but could not reach the required provider captured by a `Singleton` or `Factory`, so recreating the consumer still returned the stale value.

The original option now lazily creates and retains one required provider. `reset_cache()` cascades to that provider, deepcopy preserves the relationship, and calling `required()` on an already-required option is idempotent. This keeps the existing cache for performance, as requested in the issue discussion, instead of recomputing every access.

## Verification

- New regression on unmodified code: failed because the recreated singleton received `{"value": "initial"}` during the override.
- `.venv/bin/pytest -q tests/unit/providers/configuration/test_config_py2_py3.py::test_required_cache_is_reset_after_option_override` — 1 passed.
- `.venv/bin/pytest -q tests/unit/providers/configuration` — 204 passed.
- Related Singleton, Factory, and deepcopy test groups — 328 passed.
- The Cython extension was rebuilt successfully before the green test runs.
- The changed Python test file passes Flake8; `git diff --check` passes. (`providers.pyx` is Cython and is not directly parseable by Flake8.)
- The remote `Tests and linters` workflow is currently `action_required` and generated no jobs. This is the repository's approval gate for workflows from forks, not a test execution failure; no remote-green result is claimed before a maintainer approves it.

## Scope

The change is limited to `ConfigurationOption` cache linkage/copying and one focused regression. It does not remove caching, change configuration lookup rules, or alter `Singleton`/`Factory` behavior.

## AI assistance

OpenAI Codex (GPT-5) was used to investigate the cache lifecycle, implement the focused change and regression, rebuild the extension, and run/review the verification above. I reviewed the final diff and am disclosing this assistance explicitly.
