### PR TITLE
Fix replacement of named provider injections

### DIFF
--- a/docs/providers/factory.rst
+++ b/docs/providers/factory.rst
@@ -40,6 +40,11 @@ injected following these rules:
    :language: python
    :lines: 3-
 
+Calling ``.add_kwargs()`` or ``.add_attributes()`` with an existing name replaces
+the previous injection. The replaced provider is not called, including when it
+is asynchronous. Call-time keyword arguments still take precedence over
+registered keyword injections.
+
 ``Factory`` provider can inject attributes. Use ``.add_attributes()`` method to specify
 attribute injections.
 

--- a/src/dependency_injector/providers.pyx
+++ b/src/dependency_injector/providers.pyx
@@ -1311,7 +1311,7 @@ cdef class Callable(Provider):
 
         :return: Reference ``self``
         """
-        self._kwargs += parse_named_injections(kwargs)
+        self._kwargs = _merge_named_injections(self._kwargs, kwargs)
         self._kwargs_len = len(self._kwargs)
         return self
 
@@ -2622,7 +2622,7 @@ cdef class Factory(Provider):
 
         :return: Reference ``self``
         """
-        self._attributes += parse_named_injections(kwargs)
+        self._attributes = _merge_named_injections(self._attributes, kwargs)
         self._attributes_len = len(self._attributes)
         return self
 
@@ -3534,8 +3534,8 @@ cdef class Dict(Provider):
         if dict_ is None:
             dict_ = {}
 
-        self._kwargs += parse_named_injections(dict_)
-        self._kwargs += parse_named_injections(kwargs)
+        self._kwargs = _merge_named_injections(self._kwargs, dict_)
+        self._kwargs = _merge_named_injections(self._kwargs, kwargs)
         self._kwargs_len = len(self._kwargs)
 
         return self
@@ -3551,7 +3551,7 @@ cdef class Dict(Provider):
             dict_ = {}
 
         self._kwargs = parse_named_injections(dict_)
-        self._kwargs += parse_named_injections(kwargs)
+        self._kwargs = _merge_named_injections(self._kwargs, kwargs)
         self._kwargs_len = len(self._kwargs)
 
         return self
@@ -3815,7 +3815,7 @@ cdef class BaseResource(Provider):
 
         :return: Reference ``self``
         """
-        self._kwargs += parse_named_injections(kwargs)
+        self._kwargs = _merge_named_injections(self._kwargs, kwargs)
         self._kwargs_len = len(self._kwargs)
         return self
 
@@ -4695,6 +4695,20 @@ cpdef tuple parse_named_injections(dict kwargs):
         injections.append(injection)
 
     return tuple(injections)
+
+
+cdef tuple _merge_named_injections(tuple injections, dict kwargs):
+    """Replace named injections before any superseded provider is evaluated."""
+    cdef dict merged = {}
+    cdef NamedInjection injection
+    cdef object name
+    cdef object value
+
+    for injection in injections:
+        merged[injection._name] = injection
+    for name, value in kwargs.items():
+        merged[name] = NamedInjection(name, value)
+    return tuple(merged.values())
 
 
 cdef class OverridingContext:

--- a/tests/unit/providers/async/test_named_injection_replacement.py
+++ b/tests/unit/providers/async/test_named_injection_replacement.py
@@ -1,0 +1,101 @@
+"""Named injection replacement must discard previously registered providers."""
+
+import inspect
+from types import SimpleNamespace
+
+from dependency_injector import providers
+from pytest import mark
+
+
+@mark.asyncio
+@mark.parametrize("provider_type", [providers.Callable, providers.Factory, providers.Singleton,
+                                    providers.Resource, providers.Dict])
+@mark.parametrize("asynchronous", [False, True])
+@mark.parametrize("context", [{}, {"extra": 42}])
+async def test_add_kwargs_replaces_existing_injection(provider_type, asynchronous, context):
+    calls = []
+
+    def original():
+        calls.append(True)
+        return "original"
+
+    async def original_async():
+        return original()
+
+    dependency = providers.Callable(original_async if asynchronous else original)
+    if provider_type is providers.Dict:
+        provider = provider_type(value=dependency)
+    else:
+        provider = provider_type(dict, value=dependency)
+    provider.add_kwargs(value="intermediate").add_kwargs(value="replacement")
+
+    result = provider(**context)
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result == dict(value="replacement", **context)
+    assert calls == []
+    assert provider.kwargs == {"value": "replacement"}
+
+
+@mark.asyncio
+@mark.parametrize("provider_type", [providers.Factory, providers.Singleton])
+async def test_add_attributes_replaces_async_injection(provider_type):
+    calls = []
+
+    async def original():
+        calls.append(True)
+        return "original"
+
+    provider = provider_type(SimpleNamespace)
+    provider.add_attributes(value=providers.Callable(original))
+    provider.add_attributes(value="replacement")
+    result = provider()
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result.value == "replacement"
+    assert calls == []
+
+
+@mark.asyncio
+@mark.parametrize("method", ["__init__", "add_kwargs", "set_kwargs"])
+async def test_dict_keyword_overrides_mapping_injection(method):
+    calls = []
+
+    async def original():
+        calls.append(True)
+        return "original"
+
+    provider = providers.Dict()
+    getattr(provider, method)({"value": providers.Callable(original)}, value="replacement")
+    result = provider()
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result == {"value": "replacement"}
+    assert calls == []
+
+
+@mark.asyncio
+@mark.parametrize("provider_type", [providers.Callable, providers.Factory, providers.Singleton,
+                                    providers.Resource, providers.Dict])
+@mark.parametrize("override", [False, True])
+async def test_async_replacement_and_call_time_precedence(provider_type, override):
+    calls = []
+
+    async def replacement():
+        calls.append(True)
+        return "replacement"
+
+    if provider_type is providers.Dict:
+        provider = provider_type(value="original")
+    else:
+        provider = provider_type(dict, value="original")
+    provider.add_kwargs(value=providers.Callable(replacement))
+    result = provider(**({"value": "explicit"} if override else {}))
+    if inspect.isawaitable(result):
+        result = await result
+
+    assert result == {"value": "explicit" if override else "replacement"}
+    assert calls == ([] if override else [True])


### PR DESCRIPTION
Fixes #974.

`add_kwargs()` retained duplicate named injections. An older async dependency could finish after its replacement and overwrite the result; with extra call-time kwargs, the older entry could win immediately. Merge named injections when registering them so the latest value wins and superseded providers are never invoked. Apply the same rule to attribute injection and `Dict` mapping/keyword inputs.

Validation: 25 regression cases fail before the fix; all 35 focused cases pass afterward, including async replacements and call-time overrides. Full suite: 1,412 passed, 2 skipped before adding the final 10 focused controls. Cython limited-API build, flake8, pydocstyle, and strict mypy pass on Python 3.12/macOS. Other Python/platform combinations are left to CI.
