### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022, windows-11-arm, macos-14]
     env:
       CIBW_ENABLE: pypy
       CIBW_SKIP: "cp3??t-*"


### PR DESCRIPTION
As the title says -- the build was already structured quite nicely so it was just a matter of adding a Windows ARM64 runner to the matrix.